### PR TITLE
fix: upgrade chat server package

### DIFF
--- a/.framework/node/backend/package.json
+++ b/.framework/node/backend/package.json
@@ -15,7 +15,7 @@
     "@azure/openai": "^1.0.0-beta.10",
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "express-slow-down": "^2.0.1",
-    "mongodb-chatbot-server": "^0.3.1",
+    "mongodb-chatbot-server": "^0.9.1",
     "nodemon": "^3.0.2",
     "ts-node": "^10.9.2"
   },
@@ -25,5 +25,8 @@
     "eslint-plugin-jest": "^27.6.1",
     "prettier": "^3.1.1",
     "@types/node": "^20.10.7"
+  },
+  "overrides": {
+    "mongodb-rag-core": "0.4.1"
   }
 }

--- a/.framework/node/backend/src/app.ts
+++ b/.framework/node/backend/src/app.ts
@@ -5,7 +5,6 @@ import {
   MongoClient,
   makeMongoDbEmbeddedContentStore,
   makeMongoDbConversationsService,
-  makeDataStreamer,
   AppConfig,
   makeOpenAiChatLlm,
   SystemPrompt,
@@ -128,17 +127,15 @@ const setupApp = async () => {
 
   const conversations = makeMongoDbConversationsService(
     mongodb.db(MONGODB_DATABASE_NAME),
-    systemPrompt
   );
 
-  const dataStreamer = makeDataStreamer();
 
   const appConfig: AppConfig = {
     conversationsRouterConfig: {
-      dataStreamer,
       llm,
       conversations,
       generateUserPrompt,
+      systemPrompt,
     },
     maxRequestTimeoutMs: 30000,
   };

--- a/.framework/node/docker-compose.yml
+++ b/.framework/node/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-node:
     build: ./backend

--- a/.framework/python/docker-compose.yml
+++ b/.framework/python/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-python:
     build: ./backend

--- a/.framework/rails/docker-compose.yml
+++ b/.framework/rails/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   anythink-backend-rails:
     build: ./backend


### PR DESCRIPTION
# Description
Upgrade chat server package.
Due to this error, `Invalid parameter: expected an object (filter)` referenced in https://github.com/mongodb/chatbot/issues/425
I overrode the `mongodb-rag-core` version, since it was resolved to 0.2 which doesn't contain the fix.
Also, since it's obsolete, I removed the `version` property from the docker compose files. 